### PR TITLE
Timeout Notification Service

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 7
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - dependencies
+  - qa/automation
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue is being closed automatically as it was stale

--- a/README.md
+++ b/README.md
@@ -27,8 +27,110 @@ it will run the test for exui-common-lib
 
 Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
 
+## Timeout Notification Service
+
+The Timeout Notification Service allows your application to receive notifications
+when a User is approaching the the total time that a User has been idle for.
+
+This can be set by your application using the Timeout Notification Config object.
+
+Your application will then have to listen to events coming from the Timeout Notification Service,
+and handle these events within your application.
+
+### How to implement the Timeout Notification Service
+
+* Step 1. Import the TimeoutNotificationsService from rpx-xui-common-lib
+```
+import { TimeoutNotificationsService } from '@hmcts/rpx-xui-common-lib';
+```
+* Step 2. Add the TimeoutNotificationService to the constructor.
+```
+  constructor(
+    private readonly timeoutNotificationsService: TimeoutNotificationsService
+  ) {
+```
+* Step 3. Add a Handler, to handle the TimeoutNotificationService events.
+```
+public timeoutNotificationEventHandler(event) {
+	switch (event.eventType) {
+	  case 'countdown': {
+	  	// Implement application countdown logic, here we are using
+	  	// our timeout modal, which is another re-usable UI component.
+	    this.updateTimeoutModal(event.readableCountdown, true);
+	    return;
+	  }
+	  case 'sign-out': {
+	  	// Implement application signout logic
+	    this.updateTimeoutModal(undefined, false);
+	    return;
+	  }
+	  case 'keep-alive': {
+	  	// Implement application keep alive logic
+	    return;
+	  }
+	  default: {
+	    throw new Error('Invalid Timeout Notification Event');
+	  }
+	}
+}
+```
+* Step 4. Listen for the TimeoutNotificationService events, and send them onto the Handler.
+```
+this.timeoutNotificationsService.notificationOnChange().subscribe(event => {
+  this.timeoutNotificationEventHandler(event);
+});
+```
+* Step 5. Create a configuration object and pass the object to configure the service.
+```
+/**
+ * Timeout Notification Config
+ * 
+ * Note that idleModalDisplayTime and totalIdleTime should be passed in
+ * in milliseconds.
+ */
+const timeoutNotificationConfig: any = {
+  idleModalDisplayTime: idleModalDisplayTimeInMilliseconds,
+  totalIdleTime: totalIdleTimeInMilliseconds,
+  idleServiceName: 'idleSession'
+};
+
+this.timeoutNotificationsService.initialise(timeoutNotificationConfig);
+```
+
+### Property names explained
+
+```totalIdleTime``` is the total amount of time in milliseconds that the User is idle for. ie.
+A User is working, they then stop interacting with the page. When the User stops interacting 
+with the page is when the totalIdleTime begins.
+
+The Users Total Idle Time, includes the time in which we show the Timeout Modal to a User.
+
+```idleModalDisplayTime``` is the total amount of time in milliseconds to display a Session Timeout Modal.
+Note that our xui re-usable Session Timeout Modal can be used.
+
+*Important note*: The idleModalDisplayTime IS PART of the totalIdleTime. The idleModalDisplayTime does not get added to the end of the totalIdleTime.
+
+An example:
+`totalIdleTime: 120000`
+`idleModalDisplayTime: 60000`,
+
+totalIdleTime is 2 minutes.
+idleModalDisplayTime is 1 minute.
+
+This would lead to:
+1. On the User being idle for 1 minute, 'countdown' events are thrown.
+2. When the User is Idle for 2 minutes a 'sign-out' event is thrown. 
+3. If the User interacts with the page within this time a 'keep-alive' event is thrown.
+4. By default when the User is idle for under 1 minute, countdown events are thrown each second. 
+
+### What happens when the User is in the final minute of being idle?
+
+When the User is in the final minute of them being idle,
+countdown events are thrown every second. So that you can display
+a 60 second countdown, within your modal dialog.
+
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
 
-
+END

--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ Run `ng build` to build the exui-common-lib project. The build artifacts will be
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 it will run the test for exui-common-lib
 
-
 ## Running end-to-end tests
 
 Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
+
+## Further help
+
+To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
 
 ## Timeout Notification Service
 
@@ -97,7 +101,22 @@ const timeoutNotificationConfig: any = {
 this.timeoutNotificationsService.initialise(timeoutNotificationConfig);
 ```
 
-### Property names explained
+### What Timeout Notification Service Events should I handle?
+
+The Timeout Notification Service currently has three events that you can handle. These are:
+
+The 'countdown' event. This event dispatches a readable countdown timer in it's event payload. the countdown
+timer is a readable version of the countdown time ie. '10 seconds' or '1 minute'. Note that this dispatches
+once per second when the timer has reached less than 60 seconds till the 'sign-out' event is fired.
+
+If the 'countdown' timer is above a minute this event is dispatched every minute.
+
+The 'keep-alive' event dispatches when the User has interacted with the page again.
+
+The 'sign-out' event dispatches when the countdown timer has come to an end - when the User
+should be signed out.
+
+### What does totalIdleTime and idleModalDisplayTime mean?
 
 ```totalIdleTime``` is the total amount of time in milliseconds that the User is idle for. ie.
 A User is working, they then stop interacting with the page. When the User stops interacting 
@@ -128,9 +147,5 @@ This would lead to:
 When the User is in the final minute of them being idle,
 countdown events are thrown every second. So that you can display
 a 60 second countdown, within your modal dialog.
-
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
 
 END

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build exui-common-lib",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.16",
+  "version": "0.1.18",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0",

--- a/projects/exui-common-lib/src/lib/exui-common-lib.module.ts
+++ b/projects/exui-common-lib/src/lib/exui-common-lib.module.ts
@@ -41,6 +41,7 @@ import { FeatureToggleService } from './services/feature-toggle/feature-toggle.s
 import { LaunchDarklyService } from './services/feature-toggle/launch-darkly.service';
 import { GoogleAnalyticsService } from './services/google-analytics/google-analytics.service';
 import { ManageSessionServices } from './services/manage-session/manage-session.services';
+import { TimeoutNotificationsService } from './services/timeout-notifications/timeout-notifications.service';
 import { windowProvider, windowToken } from './window';
 import { ShareCaseComponent } from './components/share-case/share-case.component';
 import { SelectedCaseListComponent } from './components/selected-case-list/selected-case-list.component';
@@ -127,6 +128,7 @@ export class ExuiCommonLibModule {
       providers: [
         GoogleAnalyticsService,
         ManageSessionServices,
+        TimeoutNotificationsService,
         {
           provide: COMMON_LIB_ROOT_GUARD,
           useFactory: provideForRootGuard,

--- a/projects/exui-common-lib/src/lib/models/idle-config.model.ts
+++ b/projects/exui-common-lib/src/lib/models/idle-config.model.ts
@@ -4,3 +4,11 @@ export interface IdleConfigModel {
   keepAliveInSeconds: number;
   idleServiceName?: string;
 }
+
+
+export interface IdleConfig {
+  idleModalDisplayTime: number;
+  totalIdleTime: number;
+  keepAliveInSeconds: number; // Not sure what this does
+  idleServiceName?: string;
+}

--- a/projects/exui-common-lib/src/lib/models/idle-config.model.ts
+++ b/projects/exui-common-lib/src/lib/models/idle-config.model.ts
@@ -5,10 +5,3 @@ export interface IdleConfigModel {
   idleServiceName?: string;
 }
 
-
-export interface IdleConfig {
-  idleModalDisplayTime: number;
-  totalIdleTime: number;
-  keepAliveInSeconds: number; // Not sure what this does
-  idleServiceName?: string;
-}

--- a/projects/exui-common-lib/src/lib/models/timeout-notification.model.ts
+++ b/projects/exui-common-lib/src/lib/models/timeout-notification.model.ts
@@ -1,0 +1,5 @@
+export interface TimeoutNotificationConfig {
+  idleModalDisplayTime: number;
+  totalIdleTime: number;
+  idleServiceName?: string;
+}

--- a/projects/exui-common-lib/src/lib/services/manage-session/manage-session.services.ts
+++ b/projects/exui-common-lib/src/lib/services/manage-session/manage-session.services.ts
@@ -42,7 +42,6 @@ export class ManageSessionServices {
       map(sec => (sec > 60) ? Math.ceil(sec / 60) + ' minutes' : sec + ' seconds'),
       distinctUntilChanged()
     ).subscribe((countdown) => {
-      console.log('output');
       this.appStateEmitter.next({type: 'modal', countdown, isVisible: true});
     });
 

--- a/projects/exui-common-lib/src/lib/services/manage-session/manage-session.services.ts
+++ b/projects/exui-common-lib/src/lib/services/manage-session/manage-session.services.ts
@@ -7,18 +7,17 @@ import {
   distinctUntilChanged,
   map
 } from 'rxjs/operators';
-import {IdleConfig, IdleConfigModel} from '../../models/idle-config.model';
+import {IdleConfigModel} from '../../models/idle-config.model';
 
 @Injectable()
 export class ManageSessionServices {
   private readonly appStateEmitter: Subject<{type: string, countdown?: string; isVisible?: boolean}>;
-  private readonly eventEmitter: Subject<{eventType: string, readableCountdown?: string; }>;
+
   constructor(
     private readonly idle: Idle,
     private readonly keepalive: Keepalive,
   ) {
     this.appStateEmitter = new Subject();
-    this.eventEmitter = new Subject();
   }
 
   public init(idleConfig: IdleConfigModel): void {
@@ -56,84 +55,7 @@ export class ManageSessionServices {
     this.idle.watch();
   }
 
-
-  public millisecondsToSeconds = (milliseconds: number): number => milliseconds / 1000;
-
-  /**
-   * Refactored Initialise Session Timeout
-   *
-   * TODO: Everything needs to be in milliseconds
-   * TODO: Pass in minutes text
-   * TODO: Pass in seconds text
-   *
-   * There is a delay of 250 milliseconds so that the User can click on sign out? Is this
-   * still required.
-   *
-   * idleModalDisplayTime is coming in in milliseconds
-   * all inputs should be in milliseconds
-   */
-  public initialiseSessionTimeout(idleConfig: IdleConfig): void {
-
-    const MINUTES = ' minutes'
-    const SECONDS = ' seconds'
-
-    const DOCUMENT_INTERRUPTS = 'mousedown keydown DOMMouseScroll mousewheel touchstart touchmove scroll';
-
-    this.idle.setIdleName(idleConfig.idleServiceName);
-
-    // idleModalDisplayTime this comes in, in seconds
-    const idleModalDisplayTimeInSeconds = idleConfig.idleModalDisplayTime / 1000;
-    const totalIdleTimeInSeconds = idleConfig.totalIdleTime / 1000;
-
-    this.idle.setTimeout(idleModalDisplayTimeInSeconds);
-
-    const interrupt = new DocumentInterruptSource(DOCUMENT_INTERRUPTS);
-    this.idle.setInterrupts([interrupt]);
-
-    // This looks like a finishing idle end event
-    // TODO: Not sure when this is getting hit.
-    // this.idle.onIdleEnd.pipe(delay(250)).subscribe(() => {
-    //   console.log('onIdleEnd hit');
-    //   this.appStateEmitter.next({type: 'countdown', countdown: undefined});
-    // });
-
-    this.idle.onTimeout.subscribe(() => {
-      this.eventEmitter.next({eventType: 'sign-out'});
-    });
-
-    // not sure what this does.
-    // TODO: Should we pass in the minutes and seconds consts here?
-    // probably yes.
-    this.idle.onTimeoutWarning.pipe(
-      map(sec => (sec > 60) ? Math.ceil(sec / 60) + MINUTES : sec + SECONDS),
-      distinctUntilChanged()
-    ).subscribe((countdown) => {
-      this.eventEmitter.next({eventType: 'countdown', readableCountdown: countdown});
-    });
-
-    // This is set as 5 * 60 * 60
-    // TODO: Do we need this?
-    this.keepalive.interval(idleConfig.keepAliveInSeconds);
-
-    this.keepalive.onPing.subscribe(() => {
-      this.eventEmitter.next({eventType: 'keep-alive'});
-    });
-
-    const idleInSeconds = Math.floor(totalIdleTimeInSeconds) - idleModalDisplayTimeInSeconds;
-    this.idle.setIdle(idleInSeconds);
-    this.idle.watch();
-  }
-
   public appStateChanges(): Observable<any> {
     return this.appStateEmitter.asObservable();
-  }
-
-  /**
-   * Expose the events, so that the 3rd party service can listen to Timeout Notifications.
-   *
-   * TODO: Change to a more appropiate name
-   */
-  public eventEmitterChanges(): Observable<any> {
-    return this.eventEmitter.asObservable();
   }
 }

--- a/projects/exui-common-lib/src/lib/services/manage-session/manage-session.services.ts
+++ b/projects/exui-common-lib/src/lib/services/manage-session/manage-session.services.ts
@@ -7,16 +7,18 @@ import {
   distinctUntilChanged,
   map
 } from 'rxjs/operators';
-import {IdleConfigModel} from '../../models/idle-config.model';
+import {IdleConfig, IdleConfigModel} from '../../models/idle-config.model';
 
 @Injectable()
 export class ManageSessionServices {
   private readonly appStateEmitter: Subject<{type: string, countdown?: string; isVisible?: boolean}>;
+  private readonly eventEmitter: Subject<{eventType: string, readableCountdown?: string; }>;
   constructor(
     private readonly idle: Idle,
     private readonly keepalive: Keepalive,
   ) {
     this.appStateEmitter = new Subject();
+    this.eventEmitter = new Subject();
   }
 
   public init(idleConfig: IdleConfigModel): void {
@@ -41,6 +43,7 @@ export class ManageSessionServices {
       map(sec => (sec > 60) ? Math.ceil(sec / 60) + ' minutes' : sec + ' seconds'),
       distinctUntilChanged()
     ).subscribe((countdown) => {
+      console.log('output');
       this.appStateEmitter.next({type: 'modal', countdown, isVisible: true});
     });
 
@@ -53,8 +56,84 @@ export class ManageSessionServices {
     this.idle.watch();
   }
 
+
+  public millisecondsToSeconds = (milliseconds: number): number => milliseconds / 1000;
+
+  /**
+   * Refactored Initialise Session Timeout
+   *
+   * TODO: Everything needs to be in milliseconds
+   * TODO: Pass in minutes text
+   * TODO: Pass in seconds text
+   *
+   * There is a delay of 250 milliseconds so that the User can click on sign out? Is this
+   * still required.
+   *
+   * idleModalDisplayTime is coming in in milliseconds
+   * all inputs should be in milliseconds
+   */
+  public initialiseSessionTimeout(idleConfig: IdleConfig): void {
+
+    const MINUTES = ' minutes'
+    const SECONDS = ' seconds'
+
+    const DOCUMENT_INTERRUPTS = 'mousedown keydown DOMMouseScroll mousewheel touchstart touchmove scroll';
+
+    this.idle.setIdleName(idleConfig.idleServiceName);
+
+    // idleModalDisplayTime this comes in, in seconds
+    const idleModalDisplayTimeInSeconds = idleConfig.idleModalDisplayTime / 1000;
+    const totalIdleTimeInSeconds = idleConfig.totalIdleTime / 1000;
+
+    this.idle.setTimeout(idleModalDisplayTimeInSeconds);
+
+    const interrupt = new DocumentInterruptSource(DOCUMENT_INTERRUPTS);
+    this.idle.setInterrupts([interrupt]);
+
+    // This looks like a finishing idle end event
+    // TODO: Not sure when this is getting hit.
+    // this.idle.onIdleEnd.pipe(delay(250)).subscribe(() => {
+    //   console.log('onIdleEnd hit');
+    //   this.appStateEmitter.next({type: 'countdown', countdown: undefined});
+    // });
+
+    this.idle.onTimeout.subscribe(() => {
+      this.eventEmitter.next({eventType: 'sign-out'});
+    });
+
+    // not sure what this does.
+    // TODO: Should we pass in the minutes and seconds consts here?
+    // probably yes.
+    this.idle.onTimeoutWarning.pipe(
+      map(sec => (sec > 60) ? Math.ceil(sec / 60) + MINUTES : sec + SECONDS),
+      distinctUntilChanged()
+    ).subscribe((countdown) => {
+      this.eventEmitter.next({eventType: 'countdown', readableCountdown: countdown});
+    });
+
+    // This is set as 5 * 60 * 60
+    // TODO: Do we need this?
+    this.keepalive.interval(idleConfig.keepAliveInSeconds);
+
+    this.keepalive.onPing.subscribe(() => {
+      this.eventEmitter.next({eventType: 'keep-alive'});
+    });
+
+    const idleInSeconds = Math.floor(totalIdleTimeInSeconds) - idleModalDisplayTimeInSeconds;
+    this.idle.setIdle(idleInSeconds);
+    this.idle.watch();
+  }
+
   public appStateChanges(): Observable<any> {
     return this.appStateEmitter.asObservable();
   }
 
+  /**
+   * Expose the events, so that the 3rd party service can listen to Timeout Notifications.
+   *
+   * TODO: Change to a more appropiate name
+   */
+  public eventEmitterChanges(): Observable<any> {
+    return this.eventEmitter.asObservable();
+  }
 }

--- a/projects/exui-common-lib/src/lib/services/public-api.ts
+++ b/projects/exui-common-lib/src/lib/services/public-api.ts
@@ -6,3 +6,4 @@ export * from './feature-toggle/feature-toggle.service';
 export * from './feature-toggle/launch-darkly.service';
 export * from './google-analytics/google-analytics.service';
 export * from './manage-session/manage-session.services';
+export * from './timeout-notifications/timeout-notifications.service';

--- a/projects/exui-common-lib/src/lib/services/timeout-notifications/timeout-notifications.service.ts
+++ b/projects/exui-common-lib/src/lib/services/timeout-notifications/timeout-notifications.service.ts
@@ -1,0 +1,98 @@
+import { Injectable } from '@angular/core';
+import {DocumentInterruptSource, Idle, } from '@ng-idle/core';
+import {Keepalive} from '@ng-idle/keepalive';
+import {Observable, Subject} from 'rxjs';
+import {
+  distinctUntilChanged,
+  map
+} from 'rxjs/operators';
+import {IdleConfig} from '../../models/idle-config.model';
+
+@Injectable()
+export class TimeoutNotificationsService {
+
+  public readonly COUNTDOWN_EVENT: 'countdown';
+  public readonly SIGN_OUT_EVENT: 'sign-out';
+  public readonly KEEP_ALIVE_EVENT: 'keep-alive';
+
+  private readonly eventEmitter: Subject<{eventType: string, readableCountdown?: string; }>;
+
+  constructor(
+    private readonly idle: Idle,
+    private readonly keepalive: Keepalive,
+  ) {
+    this.eventEmitter = new Subject();
+  }
+
+  public millisecondsToSeconds = (milliseconds: number): number => milliseconds / 1000;
+
+  /**
+   * Refactored Initialise Session Timeout
+   *
+   * TODO: Everything needs to be in milliseconds
+   * TODO: Pass in minutes text
+   * TODO: Pass in seconds text
+   *
+   * There is a delay of 250 milliseconds so that the User can click on sign out? Is this
+   * still required.
+   *
+   * I made the decision not to make ' minutes' and ' seconds' configurable via input parameters,
+   * as I'm not sure why any team would need to change this to 'secs, mins' or 's, m' within the Reform project.
+   * - But you never know! If this needs to be changed please raise a PR.
+   *
+   * idleModalDisplayTime is coming in in milliseconds
+   * all inputs should be in milliseconds
+   *
+   * TODO: Should this function have the indivdual parameters instead of them being part of one object?
+   * There's only 3 parameters, so yes probably.
+   */
+  public initialiseSessionTimeout(idleConfig: IdleConfig): void {
+
+    const MINUTES = ' minutes'
+    const SECONDS = ' seconds'
+
+    const DOCUMENT_INTERRUPTS = 'mousedown keydown DOMMouseScroll mousewheel touchstart touchmove scroll';
+
+    this.idle.setIdleName(idleConfig.idleServiceName);
+
+    // idleModalDisplayTime this comes in, in seconds
+    const idleModalDisplayTimeInSeconds = this.millisecondsToSeconds(idleConfig.idleModalDisplayTime);
+    const totalIdleTimeInSeconds = this.millisecondsToSeconds(idleConfig.totalIdleTime);
+
+    this.idle.setTimeout(idleModalDisplayTimeInSeconds);
+
+    const interrupt = new DocumentInterruptSource(DOCUMENT_INTERRUPTS);
+    this.idle.setInterrupts([interrupt]);
+
+    this.idle.onTimeout.subscribe(() => {
+      this.eventEmitter.next({eventType: this.SIGN_OUT_EVENT});
+    });
+
+    // not sure what this does.
+    // TODO: Should we pass in the minutes and seconds consts here?
+    // probably yes.
+    this.idle.onTimeoutWarning.pipe(
+      map(sec => (sec > 60) ? Math.ceil(sec / 60) + MINUTES : sec + SECONDS),
+      distinctUntilChanged()
+    ).subscribe((countdown) => {
+      this.eventEmitter.next({eventType: this.COUNTDOWN_EVENT, readableCountdown: countdown});
+    });
+
+    this.keepalive.onPing.subscribe(() => {
+      this.eventEmitter.next({eventType: this.KEEP_ALIVE_EVENT});
+    });
+
+    const idleInSeconds = Math.floor(totalIdleTimeInSeconds) - idleModalDisplayTimeInSeconds;
+    this.idle.setIdle(idleInSeconds);
+    this.idle.watch();
+  }
+
+  /**
+   * Expose the events, so that the 3rd party service can listen to Timeout Notifications.
+   *
+   * TODO: Change to a more appropiate name
+   */
+  public eventEmitterChanges(): Observable<any> {
+    return this.eventEmitter.asObservable();
+  }
+}

--- a/projects/exui-common-lib/src/lib/services/timeout-notifications/timeout-notifications.service.ts
+++ b/projects/exui-common-lib/src/lib/services/timeout-notifications/timeout-notifications.service.ts
@@ -11,10 +11,6 @@ import {IdleConfig} from '../../models/idle-config.model';
 @Injectable()
 export class TimeoutNotificationsService {
 
-  public readonly COUNTDOWN_EVENT: 'countdown';
-  public readonly SIGN_OUT_EVENT: 'sign-out';
-  public readonly KEEP_ALIVE_EVENT: 'keep-alive';
-
   private readonly eventEmitter: Subject<{eventType: string, readableCountdown?: string; }>;
 
   constructor(
@@ -65,7 +61,7 @@ export class TimeoutNotificationsService {
     this.idle.setInterrupts([interrupt]);
 
     this.idle.onTimeout.subscribe(() => {
-      this.eventEmitter.next({eventType: this.SIGN_OUT_EVENT});
+      this.eventEmitter.next({eventType: 'sign-out'});
     });
 
     // not sure what this does.
@@ -75,11 +71,11 @@ export class TimeoutNotificationsService {
       map(sec => (sec > 60) ? Math.ceil(sec / 60) + MINUTES : sec + SECONDS),
       distinctUntilChanged()
     ).subscribe((countdown) => {
-      this.eventEmitter.next({eventType: this.COUNTDOWN_EVENT, readableCountdown: countdown});
+      this.eventEmitter.next({eventType: 'countdown', readableCountdown: countdown});
     });
 
     this.keepalive.onPing.subscribe(() => {
-      this.eventEmitter.next({eventType: this.KEEP_ALIVE_EVENT});
+      this.eventEmitter.next({eventType: 'keep-alive'});
     });
 
     const idleInSeconds = Math.floor(totalIdleTimeInSeconds) - idleModalDisplayTimeInSeconds;


### PR DESCRIPTION
Making the Timeout Notification Service reusable by any other parties at Reform. Documenting how it works.