### PR TITLE
EUI-2553/EUI-2554: Ensure uniform table column widths across multiple tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 7.3.8.
 This Project is used for EXUI team as a common library.
-All the common library is located at projects/exui-common-lib
+All the common libraries are located at `projects/exui-common-lib`.
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
-The main project is only a base to run the projects/exui-common-lib 
+Run `ng serve` (or `yarn start:no-open`) for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+The main project is only a base to run `projects/exui-common-lib`.
 
 ## Code scaffolding
 
@@ -15,12 +15,12 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the exui-common-lib project. The build artifacts will be stored in the `dist/` directory.
+Run `ng build exui-common-lib` (or `yarn build`) to build the exui-common-lib project. The build artifacts will be stored in the `dist/` directory.
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
-it will run the test for exui-common-lib
+Run `ng test exui-common-lib` (or `yarn test`) to execute the unit tests via [Karma](https://karma-runner.github.io).
+It will run the tests for exui-common-lib.
 
 ## Running end-to-end tests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build exui-common-lib",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0",

--- a/projects/exui-common-lib/src/lib/components/selected-case-confirm/selected-case-confirm.component.html
+++ b/projects/exui-common-lib/src/lib/components/selected-case-confirm/selected-case-confirm.component.html
@@ -9,9 +9,9 @@
   <table class="govuk-table">
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Name</th>
-      <th class="govuk-table__header" scope="col">Email address</th>
-      <th class="govuk-table__header" scope="col">Actions</th>
+      <th class="govuk-table__header govuk-table-column-header" scope="col">Name</th>
+      <th class="govuk-table__header govuk-table-column-header" scope="col">Email address</th>
+      <th class="govuk-table__header govuk-table-column-actions" scope="col">Actions</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">

--- a/projects/exui-common-lib/src/lib/components/selected-case-confirm/selected-case-confirm.component.scss
+++ b/projects/exui-common-lib/src/lib/components/selected-case-confirm/selected-case-confirm.component.scss
@@ -22,3 +22,9 @@
         float: right;
     }
 }
+.govuk-table-column-header {
+  width: 45%;
+}
+.govuk-table-column-actions {
+  width: 10%;
+}

--- a/projects/exui-common-lib/src/lib/components/selected-case/selected-case.component.html
+++ b/projects/exui-common-lib/src/lib/components/selected-case/selected-case.component.html
@@ -27,9 +27,9 @@
     <table class="govuk-table" *ngIf="showUserAccessTable()">
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th id="th-name" class="govuk-table__header" scope="col">Name</th>
-        <th id="th-email" class="govuk-table__header" scope="col">Email address</th>
-        <th id="th-action" class="govuk-table__header" scope="col">Actions</th>
+        <th id="th-name" class="govuk-table__header govuk-table-column-header" scope="col">Name</th>
+        <th id="th-email" class="govuk-table__header govuk-table-column-header" scope="col">Email address</th>
+        <th id="th-action" class="govuk-table__header govuk-table-column-actions" scope="col">Actions</th>
         <th id="th-label" class="govuk-table__header govuk-table-column-label" scope="col">&nbsp;&nbsp;</th>
       </tr>
       </thead>

--- a/projects/exui-common-lib/src/lib/components/selected-case/selected-case.component.scss
+++ b/projects/exui-common-lib/src/lib/components/selected-case/selected-case.component.scss
@@ -35,8 +35,14 @@
   width: 5%;
   float: left;
 }
+.govuk-table-column-header {
+  width: 40%;
+}
+.govuk-table-column-actions {
+  width: 10%;
+}
 .govuk-table-column-label {
-  width: 15%;
+  width: 10%;
 }
 .govuk-div-align-left {
   font-family: "nta", Arial, sans-serif;


### PR DESCRIPTION
Set fixed percentage widths for table columns on the "Share a case" selection and confirmation pages, ensuring uniform column alignment when multiple cases are displayed.

Resolves https://tools.hmcts.net/jira/browse/EUI-2553 and https://tools.hmcts.net/jira/browse/EUI-2554.

Notes:
* Set fixed percentage widths for table columns on the "Share a case" selection and confirmation pages, ensuring uniform column alignment when multiple cases are displayed.