### PR TITLE
EUI-2844: Wrapping error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build exui-common-lib",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0",

--- a/projects/exui-common-lib/src/lib/components/due-date/due-date.component.scss
+++ b/projects/exui-common-lib/src/lib/components/due-date/due-date.component.scss
@@ -1,4 +1,7 @@
 .due-date {
+  // Prevent text wrapping as it looks really weird. If we ever wanted
+  // this to wrap we'd have to do something about the border issue.
+  white-space: nowrap;
   &.hmcts-badge--orange {
     color: #f47738;
     border-color: #f47738;


### PR DESCRIPTION
Notes:
Prevents the Due date component from wrapping text. This fixes a rendering issue when it wraps, which it shouldn't ever need to do anyway.