### PR TITLE
EUI-2753: Checkbox list enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build exui-common-lib",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0",

--- a/projects/exui-common-lib/src/lib/components/checkbox-list/checkbox-list.component.html
+++ b/projects/exui-common-lib/src/lib/components/checkbox-list/checkbox-list.component.html
@@ -1,4 +1,4 @@
-<div class="xui-checkbox-list govuk-checkboxes govuk-checkboxes--small" *ngIf="hasOptions && labelFunction">
+<div class="xui-checkbox-list govuk-checkboxes govuk-checkboxes--small" *ngIf="isFunctional">
   <div class="select-all govuk-checkboxes__item">
     <input type="checkbox" id="select_all" class="govuk-checkboxes__input" [checked]="allSelected"
            (change)="toggleSelectAll()" />

--- a/projects/exui-common-lib/src/lib/components/checkbox-list/checkbox-list.component.spec.ts
+++ b/projects/exui-common-lib/src/lib/components/checkbox-list/checkbox-list.component.spec.ts
@@ -11,7 +11,11 @@ class WrapperComponent {
   @ViewChild(CheckboxListComponent) public appComponentRef: CheckboxListComponent<any>;
   @Input() public options: any[];
   @Input() public preselection: any[];
-  @Input() public labelFunction: (item: any) => string;
+  @Input() public labelFunction: (item: any) => string = defaultLabelFunction;
+}
+
+function defaultLabelFunction(item: any): string {
+  return item;
 }
 
 // example of a label function to mock
@@ -59,6 +63,33 @@ describe('CheckboxListComponent', () => {
     component.options.pop();
     fixture.detectChanges();
     expect(component.allSelected).toBeTruthy();
+  });
+
+  it('should allow preselection with objects', () => {
+    component.options = [{ id: 'a', name: 'Arthur' }, { id: 'b', name: 'Bob' }];
+    component.preselection = [ { id: 'c', name: 'Arthur' } ]; // Note that this is a distinct object.
+    // Based on the label function, it only cares about the name (not the id).
+    component.labelFunction = (item: { name: string }) => {
+      return item.name;
+    };
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(component.selection.length).toEqual(1);
+    expect(component.selection[0].name).toEqual('Arthur');
+    expect(component.selection[0].id).toEqual('a'); // The one in the options.
+  });
+
+  it('should prevent object preselection when it is not a valid option', () => {
+    // set the checkbox detais with preselections and expect all selected to be false
+    component.options = [{ id: 'a', name: 'Arthur' }, { id: 'b', name: 'Bob' }];
+    component.preselection = [ { id: 'a', name: 'Albert' } ]; // Note that this is a distinct object.
+    // Based on the label function, it only cares about the name.
+    component.labelFunction = (item: { name: string }) => {
+      return item.name;
+    };
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(component.selection.length).toEqual(0);
   });
 
   it('should verify when there are options to select', () => {
@@ -399,5 +430,27 @@ describe('CheckboxListComponent', () => {
     expect(element.querySelectorAll('label')[1].textContent).toContain('firstoption');
     expect(element.querySelectorAll('label')[2].textContent).toContain('secondoption');
     expect(element.querySelectorAll('label')[3].textContent).toContain('thirdoption');
+  });
+
+  it('should allow selection to be set', () => {
+    component.options = [{ id: 'a', name: 'Arthur' }, { id: 'b', name: 'Bob' }];
+    component.preselection = [ { id: 'c', name: 'Arthur' } ]; // Note that this is a distinct object.
+    // Based on the label function, it only cares about the name (not the id).
+    component.labelFunction = (item: { name: string }) => {
+      return item.name;
+    };
+    component.ngOnChanges();
+    fixture.detectChanges();
+    expect(component.selection.length).toEqual(1);
+    expect(component.selection[0].name).toEqual('Arthur');
+    expect(component.selection[0].id).toEqual('a'); // The one in the options.
+
+    component.selection = [ { name: 'Bob' } ];
+    expect(component.selection.length).toEqual(1);
+    expect(component.selection[0].name).toEqual('Bob');
+    expect(component.selection[0].id).toEqual('b'); // The one in the options.
+
+    component.selection = [ { name: 'Dave' } ];
+    expect(component.selection.length).toEqual(0);
   });
 });


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/EUI-2753
Made it possible to set the selection from outside the component and also fixed up some issues with the preselection firing before the options have been set.

Oh, and it also allows preselected objects, which wasn't possible previously (unless they were the same reference object).