### PR TITLE
Find caseworkers along with judicial workers

### DIFF
--- a/projects/exui-common-lib/src/lib/components/find-person/find-person.component.html
+++ b/projects/exui-common-lib/src/lib/components/find-person/find-person.component.html
@@ -8,7 +8,7 @@
     <div id="sub-title-hint" class="govuk-hint" *ngIf="subTitle && subTitle.length">
       {{subTitle}}
     </div>
-    <span id="validation-error" class="govuk-error-message" *ngIf="findPersonGroup.errors">
+    <span id="validation-error" class="govuk-error-message" *ngIf="findPersonGroup && findPersonGroup.errors">
         <span class="govuk-visually-hidden">Error:</span>You must select a name
     </span>
     <input id="inputSelectPerson" type="text" aria-label="select a person" matInput

--- a/projects/exui-common-lib/src/lib/components/find-person/find-person.component.ts
+++ b/projects/exui-common-lib/src/lib/components/find-person/find-person.component.ts
@@ -1,7 +1,7 @@
 import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { Observable, of } from 'rxjs';
-import { startWith, switchMap } from 'rxjs/operators';
+import { Observable, of, zip } from 'rxjs';
+import { map, startWith, switchMap } from 'rxjs/operators';
 import { Person, PersonRole } from '../../models';
 import { FindAPersonService } from '../../services/find-person/find-person.service';
 
@@ -53,8 +53,24 @@ export class FindPersonComponent implements OnInit, OnChanges {
   }
 
   public filter(searchTerm: string): Observable<Person[]> {
+    const findJudicialPeople = this.findPersonService.find({searchTerm, jurisdiction: this.domain});
+    const findCaseworkersOrAdmins = this.findPersonService.getSpecificCaseworkers({searchTerm, jurisdiction: this.domain});
     if (searchTerm && searchTerm.length > this.minSearchCharacters) {
-      return this.findPersonService.find({searchTerm, jurisdiction: this.domain});
+      switch (this.domain) {
+        case PersonRole.JUDICIAL: {
+          return findJudicialPeople;
+        }
+        case PersonRole.ALL: {
+          return zip(findJudicialPeople, findCaseworkersOrAdmins).pipe(map(separatePeople => separatePeople[0].concat(separatePeople[1])));
+        }
+        case PersonRole.CASEWORKER:
+        case PersonRole.ADMIN: {
+          return findCaseworkersOrAdmins;
+        }
+        default: {
+          return of();
+        }
+      }
     }
     return of();
   }

--- a/projects/exui-common-lib/src/lib/services/find-person/find-person.service.spec.ts
+++ b/projects/exui-common-lib/src/lib/services/find-person/find-person.service.spec.ts
@@ -1,4 +1,5 @@
-import { PersonRole } from '../../models/person.model';
+import { of } from 'rxjs';
+import { Person, PersonRole } from '../../models/person.model';
 import { FindAPersonService } from './find-person.service';
 
 describe('FindAPersonService', () => {
@@ -11,8 +12,63 @@ describe('FindAPersonService', () => {
   it('find search', () => {
     const mockHttpService = jasmine.createSpyObj('mockHttpService', ['put', 'get', 'post']);
     const service = new FindAPersonService(mockHttpService);
-    const searchOptions = { searchTerm: 'term', jurisdiction: PersonRole.CASEWORKER };
+    const searchOptions = { searchTerm: 'term', jurisdiction: PersonRole.JUDICIAL };
     service.find(searchOptions);
     expect(mockHttpService.post).toHaveBeenCalledWith('/workallocation2/findPerson', { searchOptions });
+  });
+
+  it('find specific caseworkers', () => {
+    const mockHttpService = jasmine.createSpyObj('mockHttpService', ['put', 'get', 'post']);
+    mockHttpService.get.and.returnValue(of());
+    const service = new FindAPersonService(mockHttpService);
+    const searchOptions = { searchTerm: 'term', jurisdiction: PersonRole.CASEWORKER };
+    service.getSpecificCaseworkers(searchOptions);
+    expect(mockHttpService.get).toHaveBeenCalledWith('/workallocation2/caseworker');
+  });
+
+  it('should change caseworkers to people', () => {
+    const caseworkers: any[] = [
+      {
+        idamId: '123',
+        firstName: 'Test',
+        lastName: 'One',
+        email: 'TestOne@test.com'
+      },
+      {
+        idamId: '124',
+        firstName: 'Test',
+        lastName: 'Two',
+        email: 'TestTwo@test.com'
+      },
+      {
+        idamId: '125',
+        firstName: 'Test',
+        lastName: 'Three',
+        email: 'TestThree@test.com'
+      }
+    ];
+    const people: Person[] = [
+      {
+        id: '123',
+        name: 'Test One',
+        email: 'TestOne@test.com',
+        domain: PersonRole.CASEWORKER
+      },
+      {
+        id: '124',
+        name: 'Test Two',
+        email: 'TestTwo@test.com',
+        domain: PersonRole.CASEWORKER
+      },
+      {
+        id: '125',
+        name: 'Test Three',
+        email: 'TestThree@test.com',
+        domain: PersonRole.CASEWORKER
+      }
+    ];
+    const mockHttpService = jasmine.createSpyObj('mockHttpService', ['put', 'get', 'post']);
+    const service = new FindAPersonService(mockHttpService);
+    expect(service.changeToPeople(caseworkers)).toEqual(people);
   });
 });

--- a/projects/exui-common-lib/src/lib/services/find-person/find-person.service.ts
+++ b/projects/exui-common-lib/src/lib/services/find-person/find-person.service.ts
@@ -1,8 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-import { Person } from '../../models/person.model';
+import { Person, PersonRole } from '../../models/person.model';
 import { SearchOptions } from '../../models/search-options.model';
 
 @Injectable({
@@ -14,4 +15,27 @@ export class FindAPersonService {
   public find(searchOptions: SearchOptions): Observable<Person[]> {
     return this.http.post<Person[]>('/workallocation2/findPerson', { searchOptions });
   }
+
+  public getSpecificCaseworkers(searchOptions: SearchOptions): Observable<Person[]> {
+    return this.http.get<any[]>('/workallocation2/caseworker').pipe(map(caseworkers => {
+      const people = this.changeToPeople(caseworkers);
+      return people.filter(person => person.name.toLowerCase().includes(searchOptions.searchTerm.toLowerCase()));
+    }));
+  }
+
+  public changeToPeople(caseworkers: any[]): Person[] {
+    const people: Person[] = [];
+    caseworkers.forEach((caseworker) => {
+      const thisPerson: Person = {
+        email: caseworker.email,
+        name: `${caseworker.firstName} ${caseworker.lastName}`,
+        id: caseworker.idamId,
+        domain: PersonRole.CASEWORKER,
+        // knownAs can be added if required
+      };
+      people.push(thisPerson);
+    });
+    return people;
+  }
 }
+


### PR DESCRIPTION
Resolves #https://tools.hmcts.net/jira/browse/EUI-4551. (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* Added reference to existing endpoint to get all caseworkers
* Added functionality to search through caseworkers
* Able to return both judicial users and caseworkers together (admin treated as caseworkers currently)
