### PR TITLE
Remove @ministryofjustice/frontend package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "1.4.8-new-pagination-component",
+  "version": "1.4.8-pagination-component-remove-moj-styles",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build exui-common-lib",
@@ -31,7 +31,6 @@
     "@angular/platform-browser-dynamic": "~7.2.0",
     "@angular/router": "~7.2.0",
     "@hmcts/frontend": "0.0.41-alpha",
-    "@ministryofjustice/frontend": "^1.0.0",
     "@ng-idle/core": "^8.0.0-beta.4",
     "@ng-idle/keepalive": "^8.0.0-beta.4",
     "core-js": "^2.5.4",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "1.4.8-new-pagination-component",
+  "version": "1.4.8-pagination-component-remove-moj-styles",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0",
     "@angular/material": "^7.2.0",
     "@angular/cdk": "^7.2.0",
-    "@ministryofjustice/frontend": "^1.0.0",
     "launchdarkly-js-client-sdk": "^2.15.2"
   },
   "publishConfig": {

--- a/projects/exui-common-lib/src/lib/components/pagination/pagination.component.html
+++ b/projects/exui-common-lib/src/lib/components/pagination/pagination.component.html
@@ -1,21 +1,21 @@
-<nav class="moj-pagination" id="pagination-label">
+<nav class="hmcts-pagination" id="pagination-label">
 
   <p class="govuk-visually-hidden" aria-labelledby="pagination-label">Pagination navigation</p>
 
-  <ul class="moj-pagination__list">
-    <li class="moj-pagination__item  moj-pagination__item--prev">
-      <a *ngIf="firstRecord > 1; else noPrevious" class="moj-pagination__link" (click)="onPrevious()" href="javascript:void(0)">
+  <ul class="hmcts-pagination__list">
+    <li class="hmcts-pagination__item  hmcts-pagination__item--prev">
+      <a *ngIf="firstRecord > 1; else noPrevious" class="hmcts-pagination__link" (click)="onPrevious()" href="javascript:void(0)">
         Previous page
       </a>
       <ng-template #noPrevious>
-        <span class="moj-pagination__link">Previous page</span>
+        <span class="hmcts-pagination__link">Previous page</span>
       </ng-template>
     </li>
 
-    <li class="moj-pagination__item  moj-pagination__item--next">
-      <a *ngIf="moreItems; else noNext" class="moj-pagination__link" (click)="onNext()" href="javascript:void(0)">Next page</a>
+    <li class="hmcts-pagination__item  hmcts-pagination__item--next">
+      <a *ngIf="moreItems; else noNext" class="hmcts-pagination__link" (click)="onNext()" href="javascript:void(0)">Next page</a>
       <ng-template #noNext>
-        <span class="moj-pagination__link">Next page</span>
+        <span class="hmcts-pagination__link">Next page</span>
       </ng-template>
     </li>
   </ul>

--- a/projects/exui-common-lib/src/lib/components/pagination/pagination.component.scss
+++ b/projects/exui-common-lib/src/lib/components/pagination/pagination.component.scss
@@ -1,3 +1,3 @@
-span.moj-pagination__link:hover {
+span.hmcts-pagination__link:hover {
   color: revert;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,3 @@
 /* You can add global styles to this file, and also import other style files */
-@import "../node_modules/@ministryofjustice/frontend/moj/all";
 @import "../node_modules/govuk-frontend/govuk/all";
 @import "../node_modules/@hmcts/frontend/all";

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,13 +317,6 @@
   resolved "https://registry.yarnpkg.com/@hmcts/frontend/-/frontend-0.0.41-alpha.tgz#a1f3bd75a640e92be914d42f18ce52d3dea770d2"
   integrity sha512-1EJhRYycSMsTUYAx+FsrQ3O9mB9WVsoULikd4J9Xu9nSMk2D4mABIzRdcqvXvlIIMSmVDXJD2xDxInJBg57TsA==
 
-"@ministryofjustice/frontend@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-1.0.0.tgz#8eac0314e03a826c037c6bad512f7de1a49461bf"
-  integrity sha512-LCpaODwEiax5HCw1eF7RE6Nt4u5NkURUlX79s+2FD+xJRRIHeCmOIyrHQXJFiaC+5TYlZPtfCZZO1BF0WJAiNg==
-  dependencies:
-    moment "^2.27.0"
-
 "@ng-idle/core@^8.0.0-beta.4":
   version "8.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@ng-idle/core/-/core-8.0.0-beta.4.tgz#c856bb2dd3c8407321380faac8c5692a5728fd0d"
@@ -4884,11 +4877,6 @@ mkdirp@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-moment@^2.27.0:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
`@ministryofjustice/frontend` package no longer required since there are CSS style equivalents in `@hmcts/frontend` that the Global Search pagination component can use.