### PR TITLE
EUI-4863: Date validation fixes for Global Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "1.4.30-date-component-common-validation",
+  "version": "1.4.31-date-component-validation-fixes",
   "scripts": {
     "ng": "ng",
     "build:library": "ng build exui-common-lib",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "1.4.30-date-component-common-validation",
+  "version": "1.4.31-date-component-validation-fixes",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0",

--- a/projects/exui-common-lib/src/lib/gov-ui/components/gov-uk-date/gov-uk-date.component.spec.ts
+++ b/projects/exui-common-lib/src/lib/gov-ui/components/gov-uk-date/gov-uk-date.component.spec.ts
@@ -72,10 +72,115 @@ describe('GovUkDateComponent', () => {
       id_month: new FormControl('', null),
       id_year: new FormControl('', null)
     });
-    fixture.detectChanges();
     component.formGroup.get('id_day').patchValue('01');
     component.formGroup.get('id_month').patchValue('13');
     component.formGroup.get('id_year').patchValue('2021');
+    fixture.detectChanges();
+
+    expect(component.formGroup.status).toBe('INVALID');
+  });
+
+  it('should fail validation if the day is blank (empty string)', () => {
+    const dateValidator = component.DateValidator();
+    component.formGroup = new FormGroup({
+      id_day: new FormControl('', dateValidator),
+      id_month: new FormControl('', null),
+      id_year: new FormControl('', null)
+    });
+    component.formGroup.get('id_month').patchValue('01');
+    component.formGroup.get('id_year').patchValue('2021');
+    fixture.detectChanges();
+
+    expect(component.formGroup.status).toBe('INVALID');
+  });
+
+  it('should fail validation if the month is blank (null)', () => {
+    const dateValidator = component.DateValidator();
+    component.formGroup = new FormGroup({
+      id_day: new FormControl('', dateValidator),
+      id_month: new FormControl('', null),
+      id_year: new FormControl('', null)
+    });
+    component.formGroup.get('id_day').patchValue('01');
+    component.formGroup.get('id_month').patchValue(null);
+    component.formGroup.get('id_year').patchValue('2021');
+    fixture.detectChanges();
+
+    expect(component.formGroup.status).toBe('INVALID');
+  });
+
+  it('should fail validation if the year is blank (null)', () => {
+    const dateValidator = component.DateValidator();
+    component.formGroup = new FormGroup({
+      id_day: new FormControl('', dateValidator),
+      id_month: new FormControl('', null),
+      id_year: new FormControl('', null)
+    });
+    component.formGroup.get('id_day').patchValue('01');
+    component.formGroup.get('id_month').patchValue('01');
+    component.formGroup.get('id_year').patchValue(null);
+    fixture.detectChanges();
+
+    expect(component.formGroup.status).toBe('INVALID');
+  });
+
+  it('should pass validation if the date is optional and day, month, and year are all empty (month is undefined)', () => {
+    const dateValidator = component.DateValidator();
+    component.formGroup = new FormGroup({
+      id_day: new FormControl('', dateValidator),
+      id_month: new FormControl('', null),
+      id_year: new FormControl('', null)
+    });
+    // Check that null and undefined are treated as empty values
+    component.formGroup.get('id_day').patchValue(null);
+    component.formGroup.get('id_month').patchValue(undefined);
+    component.isOptional = true;
+    fixture.detectChanges();
+
+    expect(component.formGroup.status).toBe('VALID');
+  });
+
+  it('should pass validation if the date is optional and day, month, and year are all empty (month is null)', () => {
+    const dateValidator = component.DateValidator();
+    component.formGroup = new FormGroup({
+      id_day: new FormControl('', dateValidator),
+      id_month: new FormControl('', null),
+      id_year: new FormControl('', null)
+    });
+    // Check month is treated as empty if value is null - remember that a -1 offset is applied!
+    component.formGroup.get('id_month').patchValue(null);
+    component.isOptional = true;
+    fixture.detectChanges();
+
+    expect(component.formGroup.status).toBe('VALID');
+  });
+
+  it('should pass validation if the date is optional and day, month, and year are all empty (month is empty string)', () => {
+    const dateValidator = component.DateValidator();
+    component.formGroup = new FormGroup({
+      id_day: new FormControl('', dateValidator),
+      id_month: new FormControl('', null),
+      id_year: new FormControl('', null)
+    });
+    // Check month is treated as empty if value is empty string - remember that a -1 offset is applied!
+    component.isOptional = true;
+    fixture.detectChanges();
+
+    expect(component.formGroup.status).toBe('VALID');
+  });
+
+  it('should fail validation if the date is optional but day, month, or year are not empty', () => {
+    const dateValidator = component.DateValidator();
+    component.formGroup = new FormGroup({
+      id_day: new FormControl('', dateValidator),
+      id_month: new FormControl('', null),
+      id_year: new FormControl('', null)
+    });
+    // Check that null and undefined are treated as empty values
+    component.formGroup.get('id_day').patchValue(null);
+    component.formGroup.get('id_month').patchValue(undefined);
+    component.formGroup.get('id_year').patchValue('2021');
+    component.isOptional = true;
     fixture.detectChanges();
 
     expect(component.formGroup.status).toBe('INVALID');


### PR DESCRIPTION
Allow date field to be optional (and thus bypass any validation); fix bug where a date with day and month but no year is wrongly treated as valid.