### PR TITLE
EXUI-2202: Add error handling on location search when RD req fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.25-search-location-fix",
+  "version": "2.0.26",
   "engines": {
     "node": ">=18.19.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.25",
+  "version": "2.0.25-search-location-fix",
   "engines": {
     "node": ">=18.19.0"
   },

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.25",
+  "version": "2.0.25-search-location-fix",
   "peerDependencies": {
     "launchdarkly-js-client-sdk": "^3.3.0",
     "ngx-pagination": "^3.2.1",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.25-search-location-fix",
+  "version": "2.0.26",
   "peerDependencies": {
     "launchdarkly-js-client-sdk": "^3.3.0",
     "ngx-pagination": "^3.2.1",

--- a/projects/exui-common-lib/src/lib/components/search-location/search-location.component.ts
+++ b/projects/exui-common-lib/src/lib/components/search-location/search-location.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { iif, Observable, of } from 'rxjs';
-import { debounceTime, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, debounceTime, map, switchMap, tap } from 'rxjs/operators';
 import {
   BookingCheckType, FilterConfigOption,
   FilterFieldConfig,
@@ -93,6 +93,10 @@ export class SearchLocationComponent implements OnInit {
           () => (!!term && term.length >= this.minSearchCharacters),
           this.getLocations(term).pipe(
             map((locations) => this.filterUnselectedLocations(locations, this.selectedLocations, this.singleMode)),
+            catchError(() => {
+              // returns false so the user is not shown the no results found message
+              return of(false);
+            }),
           ),
           of(false)
         )),


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

https://tools.hmcts.net/jira/browse/EXUI-2202?src=confmacro

Notes:
* Handle any errors thrown by RD on the search locations input so the user can still use the input without having to refresh

