### PR TITLE
cot-874 - enabling the option to resubmit form after re-set to default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.30",
+  "version": "2.0.30-COT-874",
   "engines": {
     "node": ">=18.19.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.30-COT-874",
+  "version": "2.0.30-COT-874-v2",
   "engines": {
     "node": ">=18.19.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.30-COT-874-v2",
+  "version": "2.0.30-COT-874-v3",
   "engines": {
     "node": ">=18.19.0"
   },

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.30",
+  "version": "2.0.30-COT-874",
   "peerDependencies": {
     "launchdarkly-js-client-sdk": "^3.3.0",
     "ngx-pagination": "^3.2.1",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.30-COT-874-v2",
+  "version": "2.0.30-COT-874-v3",
   "peerDependencies": {
     "launchdarkly-js-client-sdk": "^3.3.0",
     "ngx-pagination": "^3.2.1",

--- a/projects/exui-common-lib/package.json
+++ b/projects/exui-common-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/rpx-xui-common-lib",
-  "version": "2.0.30-COT-874",
+  "version": "2.0.30-COT-874-v2",
   "peerDependencies": {
     "launchdarkly-js-client-sdk": "^3.3.0",
     "ngx-pagination": "^3.2.1",

--- a/projects/exui-common-lib/src/lib/components/generic-filter/generic-filter.component.html
+++ b/projects/exui-common-lib/src/lib/components/generic-filter/generic-filter.component.html
@@ -205,7 +205,7 @@
       >{{(config.applyButtonText || 'Apply') | rpxTranslate}}</button>
       <button *ngIf="config.showCancelFilterButton"
         class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0"
-        [type]="config.resubmitOnCancel ? 'submit' : 'button'"
+        [type]="config.submitOnCancel ? 'submit' : 'button'"
         id="cancelFilter"
         (click)="cancelFilter()">{{ (config.cancelButtonText || 'Cancel') | rpxTranslate}}</button>
     </div>

--- a/projects/exui-common-lib/src/lib/components/generic-filter/generic-filter.component.html
+++ b/projects/exui-common-lib/src/lib/components/generic-filter/generic-filter.component.html
@@ -205,7 +205,7 @@
       >{{(config.applyButtonText || 'Apply') | rpxTranslate}}</button>
       <button *ngIf="config.showCancelFilterButton"
         class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0"
-        type="button"
+        [type]="config.resubmitOnCancel ? 'submit' : 'button'"
         id="cancelFilter"
         (click)="cancelFilter()">{{ (config.cancelButtonText || 'Cancel') | rpxTranslate}}</button>
     </div>

--- a/projects/exui-common-lib/src/lib/components/generic-filter/generic-filter.component.spec.ts
+++ b/projects/exui-common-lib/src/lib/components/generic-filter/generic-filter.component.spec.ts
@@ -699,7 +699,7 @@ describe('cancel button operation options', () => {
       applyButtonText: 'apply', id: 'example', persistence: 'session',
       showCancelFilterButton: true,
       cancelButtonText: 'Reset to default',
-      resubmitOnCancel: true,
+      submitOnCancel: true,
       fields: []
     };
 
@@ -715,7 +715,7 @@ describe('cancel button operation options', () => {
       applyButtonText: 'apply', id: 'example', persistence: 'session',
       showCancelFilterButton: true,
       cancelButtonText: 'Reset to default',
-      resubmitOnCancel: false,
+      submitOnCancel: false,
       fields: []
     };
     fixture.detectChanges();

--- a/projects/exui-common-lib/src/lib/components/generic-filter/generic-filter.component.spec.ts
+++ b/projects/exui-common-lib/src/lib/components/generic-filter/generic-filter.component.spec.ts
@@ -678,6 +678,53 @@ describe('Find location filter config', () => {
   });
 });
 
+describe('cancel button operation options', () => {
+  let component: GenericFilterComponent;
+  let fixture: ComponentFixture<GenericFilterComponent>;
+  let cancelButton = null;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [GenericFilterComponent, RpxTranslateMockPipe],
+      imports: [ReactiveFormsModule],
+      providers: [FilterService]
+    }).compileComponents();
+  });
+
+  it('should set cancel button type to submit if resubmitOnCancel is true', () => {
+
+    fixture = TestBed.createComponent(GenericFilterComponent);
+    component = fixture.componentInstance;
+    component.config = {
+      applyButtonText: 'apply', id: 'example', persistence: 'session',
+      showCancelFilterButton: true,
+      cancelButtonText: 'Reset to default',
+      resubmitOnCancel: true,
+      fields: []
+    };
+
+    fixture.detectChanges();
+    cancelButton = fixture.debugElement.query(By.css('#cancelFilter'));
+    expect(cancelButton.attributes.type).toBe('submit');
+  });
+
+  it('should set cancel button type to button if resubmitOnCancel is false', () => {
+    fixture = TestBed.createComponent(GenericFilterComponent);
+    component = fixture.componentInstance;
+    component.config = {
+      applyButtonText: 'apply', id: 'example', persistence: 'session',
+      showCancelFilterButton: true,
+      cancelButtonText: 'Reset to default',
+      resubmitOnCancel: false,
+      fields: []
+    };
+    fixture.detectChanges();
+
+    cancelButton = fixture.debugElement.query(By.css('#cancelFilter'));
+    expect(cancelButton.attributes.type).toBe('button');
+  });
+});
+
 describe('Task Name Filter', () => {
   let component: GenericFilterComponent;
   let fixture: ComponentFixture<GenericFilterComponent>;

--- a/projects/exui-common-lib/src/lib/models/filter.model.ts
+++ b/projects/exui-common-lib/src/lib/models/filter.model.ts
@@ -21,7 +21,7 @@ export interface FilterConfig {
   cancelButtonText: string;
   cancelSetting?: FilterSetting;
   showCancelFilterButton?: boolean;
-  resubmitOnCancel?: boolean;
+  submitOnCancel?: boolean;
   preSelectedNestedCheckbox?: number[];
   cancelButtonCallback?(): void;
   applyButtonCallback?(): void;

--- a/projects/exui-common-lib/src/lib/models/filter.model.ts
+++ b/projects/exui-common-lib/src/lib/models/filter.model.ts
@@ -21,6 +21,7 @@ export interface FilterConfig {
   cancelButtonText: string;
   cancelSetting?: FilterSetting;
   showCancelFilterButton?: boolean;
+  resubmitOnCancel?: boolean;
   preSelectedNestedCheckbox?: number[];
   cancelButtonCallback?(): void;
   applyButtonCallback?(): void;


### PR DESCRIPTION
Notes:
* new variable resubmitOnCancel added giving the option to redefine the cancel button as a submit.  This is for the request to have the reset to default button in All Work to re-submit the form when selected and not require the user to then hit the apply button

